### PR TITLE
Add missing 2.7 compatibility note

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -47,15 +47,15 @@ The following table provides version and version-support information about <%= v
     </tr>
     <tr>
         <td>Compatible <%= vars.ops_manager_full %> versions</td>
-        <td>2.10, 2.9, and 2.8</td>
+        <td>2.10, 2.9, 2.8 and 2.7</td>
     </tr>
     <tr>
         <td>Compatible <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) versions</td>
-        <td>2.11, 2.10, 2.9, and 2.8</td>
+        <td>2.11, 2.10, 2.9, 2.8 and 2.7</td>
     </tr>
     <tr>
         <td>Compatible <%= vars.windows_runtime_full %> (<%= vars.windows_runtime_abbr %>) versions</td>
-        <td>2.11, 2.10, 2.9, and 2.8</td>
+        <td>2.11, 2.10, 2.9, 2.8 and 2.7</td>
     </tr>
     <tr>
         <td>Compatible BOSH stemcells</td>


### PR DESCRIPTION
FIM is compatible with 2.7 and this is missing from the documentation.

Which other branches should this be merged with (if any)?
