### PR TITLE
Add `Releases` title to release notes page

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -9,18 +9,20 @@ This topic contains release notes for <%= vars.product_full %> (<%= vars.product
 
 <%= partial vars.path_to_partials + "/upgrade-planner" %>
 
-## <a id="2-1-8"></a> v2.1.8
+## <a id='releases'></a> Releases
+
+### <a id="2-1-8"></a> v2.1.8
 
 **Release Date: October 28, 2021**
 
-### Features
+#### Features
 
 New features and changes in this release:
 
 * **New patches for Go:** Adds latest patches for all Go dependencies
 * **Golang update:** Updates golang dependency to v1.16 for both Linux and Windows
 
-### Known Issues
+#### Known Issues
 
 This release has the following known issue:
 
@@ -31,18 +33,18 @@ This release has the following known issue:
   metadata keys.
   For more information, see [Metadata](installing.html#metadata).
 
-## <a id="2-1-5"></a> v2.1.5
+### <a id="2-1-5"></a> v2.1.5
 
 **Release Date: January 25, 2021**
 
-### Features
+#### Features
 
 New features and changes in this release:
 
 * General Availability of <%= vars.product_abbr %> for Windows.
 * Updates golang dependency to v1.15 for both Linux and Windows.
 
-### Known Issues
+#### Known Issues
 
 This release has the following known issue:
 
@@ -53,11 +55,11 @@ However, you can determine the correct username and group name for a file from t
 metadata keys.
 For more information, see [Metadata](installing.html#metadata).
 
-## <a id="2-1-3"></a> v2.1.3
+### <a id="2-1-3"></a> v2.1.3
 
 **Release Date**: May 20, 2020
 
-### Features
+#### Features
 
 New features and changes in this release:
 
@@ -75,7 +77,7 @@ For more information, see [In-Memory Cache](installing.html#in-memory-cache).
 * Adds security metadata for `CREATE` and `CHMOD` events on Linux.
 For more information, see [Metadata](installing.html#metadata).
 
-### Known Issues
+#### Known Issues
 
 This release has the following known issue:
 


### PR DESCRIPTION
This title is used by the Cryogenics automation.

Release notes for new versions will be appended just after this title.
